### PR TITLE
Access / Override issue

### DIFF
--- a/SampleProject/Haxe/src/UEMetadata.hx
+++ b/SampleProject/Haxe/src/UEMetadata.hx
@@ -249,6 +249,7 @@ class UEMetadata {
 		}
 
 		final originalName = field.name;
+		var access = field.access.concat([]);
 		if(field.access != null && field.access.contains(AOverride)) {
 			field.access.remove(AOverride);
 		}
@@ -271,7 +272,7 @@ class UEMetadata {
 				},
 				args: funData.args
 			}),
-			access: [AOverride]
+			access: access
 		};
 
 		/*


### PR DESCRIPTION
This change addresses an issue where if a function is declared as a `ufunc`, eg:

```
@:ufunc()
public function BlueprintFunc() {
   trace("This function can be called from blueprints.");
}
```
The following error is shown when compiling the haxe cpp:

```
Field BlueprintFunc is declared 'override' but doesn't override any field
```