### PR TITLE
Disable shadow variable errors

### DIFF
--- a/SampleProject/Source/HaxeCompatibility/HaxeCompatibility.Build.cs
+++ b/SampleProject/Source/HaxeCompatibility/HaxeCompatibility.Build.cs
@@ -8,6 +8,9 @@ public class HaxeCompatibility: ModuleRules {
 
 		bUseRTTI = true;
 
+		// Disable shadow variable errors
+		bEnableShadowVariableWarnings = false;
+
 		// ========================================================================================
 		// * INCLUDE PATHS
 		// ========================================================================================


### PR DESCRIPTION
Disable shadow variable errors with `bEnableShadowVariableWarnings = false;`

While redefined local variables aren't ideal, Haxe's output is done in a safe manner, so it's safe to ignore these errors