### PR TITLE
GenerateUE5ExternsForHaxe.hpp UE4 compatibility

### DIFF
--- a/ExternGenerator/GenerateUE5ExternsForHaxe.hpp
+++ b/ExternGenerator/GenerateUE5ExternsForHaxe.hpp
@@ -117,9 +117,11 @@ FString ConvertFPropertyToHaxeTypeString(FProperty* prop);
 // This saves the provided "content" string into a file located at "HAXE_FILE_SAVE_PATH" named "filename".
 // Used to create the .hx source files.
 void SaveHaxeFile(const FString& filename, const FString& content) {
-	static FString Dir = HAXE_FILE_SAVE_PATH_RELATIVE ? (FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), HAXE_FILE_SAVE_PATH))) : HAXE_FILE_SAVE_PATH;
-
-	auto file = Dir.Replace(TEXT("%s"), *filename);
+	static FString _RelativePath = HAXE_FILE_SAVE_PATH;
+	FString RelativePath = _RelativePath.Replace(TEXT("%s"), *filename);
+	FString ProjectDirAndHaxeSavePath = FPaths::Combine(FPaths::ProjectDir(), RelativePath);
+	FString AbsolutePath = FPaths::ConvertRelativePathToFull(ProjectDirAndHaxeSavePath);
+	FString file = HAXE_FILE_SAVE_PATH_RELATIVE ? AbsolutePath : ProjectDirAndHaxeSavePath;
 	FFileHelper::SaveStringToFile(content, *file);
 }
 
@@ -1002,7 +1004,7 @@ void SaveExtraExtern(ExtraExtern& extraExtern) {
 	for(auto& v : extraExtern.Variables) {
 		haxeSource += "\t" + v + ";\n";
 	}
-	if(!extraExtern.Variables.IsEmpty() && !extraExtern.Functions.IsEmpty()) {
+	if(extraExtern.Variables.Num() > 0 && extraExtern.Functions.Num() > 0) {
 		haxeSource += "\n";
 	}
 	for(auto& v : extraExtern.Functions) {


### PR DESCRIPTION
Address two issues when targeting ue4.27:
* I was getting errors when trying to use IsEmpty() on line 1005, so switch to .Num() instead
* Current SaveHaxeFile function outputting everything to a single file with characters like `亀뼥ʬ`