### PR TITLE
Address StdLib.cpp Localization issue

### DIFF
--- a/SampleProject/Source/HaxeCompatibility/HaxeCompatibility.cpp
+++ b/SampleProject/Source/HaxeCompatibility/HaxeCompatibility.cpp
@@ -1,6 +1,7 @@
 #include "HaxeCompatibility.h"
 
 #include "hxcpp.h"
+#include <locale.h>
 
 #define LOCTEXT_NAMESPACE "FHaxeCompatibilityModule"
 
@@ -9,6 +10,7 @@ void FHaxeCompatibilityModule::StartupModule() {
 	::hx::SetTopOfStack(&top, true);
 	::hx::Boot();
 	__boot_all();
+	setlocale(LC_ALL, "C");
 	::hx::SetTopOfStack((int*)0, true);
 
 	UE_LOG(LogTemp, Warning, TEXT("Haxe Loaded and Ready!"));


### PR DESCRIPTION
This effectively undoes line 272 in StdLibs.cpp `setlocale(LC_ALL, "");` as without doing this there is a compile error during packaging / cooking when Localization is being used